### PR TITLE
fix the check if the user wants to overrule rg_root_types

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -16,7 +16,7 @@ if !exists('g:rg_command')
   let g:rg_command = g:rg_binary . ' --vimgrep'
 endif
 
-if !exists('g:rg_rootfiles')
+if !exists('g:rg_root_types')
   let g:rg_root_types = ['.git']
 endif
 


### PR DESCRIPTION
The user can not overrule g:rg_root_types in vimrc without defining g:rg_rootfiles.
This patch will check if g:rg_root_types is defined by the user in stead.