### PR TITLE
escape vertical bars (`|`) in keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ Word under cursor will be searched if no argument is passed to `Rg`
 ## configuration
 
 
-| Setting          | Default                   | Details
-| -----------------|---------------------------|----------
-| g:rg_binary      | rg                        | path to rg
-| g:rg_format      | %f:%l:%c:%m               | value of grepformat 
-| g:rg_command     | g:rg_binary --vimgrep     | search command
-| g:rg_highlight   | false                     | true if you want matches highlighted
-| g:rg_derive_root | false                     | true if you want to find project root from cwd
-| g:rg_root_types  | ['.git']                  | list of files/dir found in project root
-    
+| Setting           | Default                   | Details
+| ------------------|---------------------------|----------
+| g:rg_binary       | rg                        | path to rg
+| g:rg_format       | %f:%l:%c:%m               | value of grepformat 
+| g:rg_command      | g:rg_binary --vimgrep     | search command
+| g:rg_highlight    | false                     | true if you want matches highlighted
+| g:rg_derive_root  | false                     | true if you want to find project root from cwd
+| g:rg_root_types   | ['.git']                  | list of files/dir found in project root
+| g:rg_escape_vbars | false                     | true if you want to escape vertical bars (`|`) in the keyword
+
 ## misc
 
 Show root search dir

--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -21,7 +21,11 @@ if !exists('g:rg_root_types')
 endif
 
 fun! s:Rg(txt)
-  call s:RgGrepContext(function('s:RgSearch'), s:RgSearchTerm(a:txt))
+  let l:txt = a:txt
+  if exists('g:rg_escape_vbars')
+    let l:txt = escape(l:txt, '|')
+  endif
+  call s:RgGrepContext(function('s:RgSearch'), s:RgSearchTerm(l:txt))
 endfun
 
 fun! s:RgSearchTerm(txt)


### PR DESCRIPTION
Searching some words in `Rg` with a following command, I cannot found any lines.

```
:Rg 'OWNER|NAME'
```

Even though some lines contain "OWNER" or "NAME"...
Tried to get logs, I found a line of problem.

```
:!./rg --vimgrep 'OWNER 2>&1| tee /var/folders/1z/271lqzy54m51c2y_bjt5n4h00000gn/T/vlLCT7l/1
```

A vertical bar (`|`) is mistakenly construed as a pipe.
So in keywords, bars should be escaped.
Yes, it can be done manually, but it's nonsense I think.
  