### PR TITLE
Set the 'quickfix' window apears at the bottom

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -35,7 +35,7 @@ endfun
 fun! s:RgSearch(txt)
   silent! exe 'grep! ' . a:txt
   if len(getqflist())
-    copen
+    botright copen
     redraw!
     if exists('g:rg_highlight')
       call s:RgHighlight(a:txt)


### PR DESCRIPTION
It is about #7. If the screen is separated to several windows,
this will help to make the quickfix windows appear at the bottom
of the screen.