### PR TITLE
Hide the search output during the search.

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -61,7 +61,9 @@ fun! s:RgGrepContext(search, txt)
   let l:shellpipe_bak=&shellpipe
   set t_te=
   set t_ti=
-  let &shellpipe="&>"
+  if !has("win32")
+    let &shellpipe="&>"
+  endif
 
   if exists('g:rg_derive_root')
     call s:RgPathContext(a:search, a:txt)

--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -58,8 +58,10 @@ fun! s:RgGrepContext(search, txt)
   let &grepformat = g:rg_format
   let l:te = &t_te
   let l:ti = &t_ti
+  let l:shellpipe_bak=&shellpipe
   set t_te=
   set t_ti=
+  let &shellpipe="&>"
 
   if exists('g:rg_derive_root')
     call s:RgPathContext(a:search, a:txt)
@@ -67,6 +69,7 @@ fun! s:RgGrepContext(search, txt)
     call a:search(a:txt)
   endif
 
+  let &shellpipe=l:shellpipe_bak
   let &t_te=l:te
   let &t_ti=l:ti
   let &grepprg = l:grepprgb


### PR DESCRIPTION
This is a fix for #8. The patch is tested on Vim 8.0 on Debian 8 and Windows10 and macOS High Sierra.