### PR TITLE
Allow passing arbitrary arguments and paths to Rg command

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -25,7 +25,7 @@ if !exists('g:rg_window_location')
 endif
 
 fun! g:RgVisual() range
-  call s:RgGrepContext(function('s:RgSearch'), s:RgGetVisualSelection())
+  call s:RgGrepContext(function('s:RgSearch'), '"' . s:RgGetVisualSelection() . '"')
 endfun
 
 fun! s:Rg(txt)
@@ -61,7 +61,7 @@ fun! s:RgSearch(txt)
   if &smartcase == 1
     let l:rgopts = l:rgopts . '-S '
   endif
-  silent! exe 'grep! ' . l:rgopts . '"' . a:txt . '"'
+  silent! exe 'grep! ' . l:rgopts . a:txt
   if len(getqflist())
     exe g:rg_window_location 'copen'
     redraw!


### PR DESCRIPTION
- Only wrap the search string in quotes during visual search. As was the behavior prior to 7d01d697.
- Restore the ability to use all ripgrep features from command mode:
  `:Rg --fixed-strings \.Model service/`

fixes #25