### PR TITLE
allow using the bang modifier with the Rg command

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -145,5 +145,5 @@ fun! s:RgShowRoot()
   endif
 endfun
 
-command! -nargs=* -complete=file Rg :call s:Rg(<q-args>)
+command! -nargs=* -complete=file -bang Rg :call s:Rg(<q-args>)
 command! -complete=file RgRoot :call s:RgShowRoot()


### PR DESCRIPTION
supplying a bang has no effect, but permits :rg! as a drop-in replacement
for grep!.