### PR TITLE
Don't depend on bash extension

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -86,7 +86,7 @@ fun! s:RgGrepContext(search, txt)
   set t_te=
   set t_ti=
   if !has("win32")
-    let &shellpipe="&>"
+    let &shellpipe="2>&1 | cat >"
   endif
 
   if exists('g:rg_derive_root')


### PR DESCRIPTION
`&>` is a bash extension (also supported by some other shells, but not all). This adds support for other shells including sh and fish.

I wish there were a cleaner way of doing this, but `2>&1 >` doesn't have the desired effect of redirecting stderr properly. I don't know of a way to tell vim to do `>filename 2>&1` with shellpipe, although shellredir looks promising.