### PR TITLE
Fix E1208 started showing up in Vim v8.2.3149

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -146,4 +146,4 @@ fun! s:RgShowRoot()
 endfun
 
 command! -nargs=* -complete=file Rg :call s:Rg(<q-args>)
-command! -complete=file RgRoot :call s:RgShowRoot()
+command! RgRoot :call s:RgShowRoot()


### PR DESCRIPTION
`-complete` is not needed since `:RgRoot` takes no arguments.
This fix prevents the error E1208 at Vim starts up with Vim v8.2.3149 or newer.

```
$ vim --version | head -2
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Jul 12 2021 09:32:07)
Included patches: 1-3154

$ vim
Error detected while processing /home/xxx/.vim/pack/minpac/start/vim-ripgrep/plugin/vim-ripgrep.vim:
line  149: E1208: -complete used without -nargsPress ENTER or type command to continue
```