### PR TITLE
correct nargs errors for vim 8.2.3150+

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -145,5 +145,5 @@ fun! s:RgShowRoot()
   endif
 endfun
 
-command! -nargs=* -complete=file Rg :call s:Rg(<q-args>)
-command! -complete=file RgRoot :call s:RgShowRoot()
+command! -nargs=? -complete=file Rg :call s:Rg(<q-args>)
+command! -nargs=? -complete=file RgRoot :call s:RgShowRoot()


### PR DESCRIPTION
https://github.com/vim/vim/pull/8544 introduced a change that displays an error when `nargs` is not defined and/or defined incorrectly. As a user, this will display an error message each time upon starting up. The error shows up as
```
Error detected while processing ~/.vim/plugged/vim-ripgrep/plugin/vim-ripgrep.vim:
line  149: E1208: -complete used without -nargs
Press ENTER or type command to continue
```

This fix to add `-nargs=?` to each of the `command`s.

Fixes #57