### PR TITLE
Remove unnecessary -complete=file for RgRoot

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -146,4 +146,4 @@ fun! s:RgShowRoot()
 endfun
 
 command! -nargs=* -complete=file Rg :call s:Rg(<q-args>)
-command! -complete=file RgRoot :call s:RgShowRoot()
+command! RgRoot :call s:RgShowRoot()


### PR DESCRIPTION
This fixes this error: `line  149: E1208: -complete used without allowing arguments`

Ref: https://github.com/vim/vim/pull/8544