### PR TITLE
fix: remove -complete from RgRoot to resolve E1208 error

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -146,4 +146,4 @@ fun! s:RgShowRoot()
 endfun
 
 command! -nargs=* -complete=file Rg :call s:Rg(<q-args>)
-command! -complete=file RgRoot :call s:RgShowRoot()
+command! RgRoot :call s:RgShowRoot()


### PR DESCRIPTION
fix: remove -complete from RgRoot to resolve E1208 (-complete used without -nargs) error