### PR TITLE
fix E1208 error

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -146,4 +146,4 @@ fun! s:RgShowRoot()
 endfun
 
 command! -nargs=* -complete=file Rg :call s:Rg(<q-args>)
-command! -complete=file RgRoot :call s:RgShowRoot()
+command! RgRoot :call s:RgShowRoot()


### PR DESCRIPTION
`RgShowRoot()` doesn't take any args so having `-nargs=*` causes a  warning when opening Vim. Removing that fixes it while being able to call the `:RgRoot` function still.