### PR TITLE
Escaping Command-line special characters '#', '%' and '|'

### DIFF
--- a/plugin/vim-ripgrep.vim
+++ b/plugin/vim-ripgrep.vim
@@ -61,7 +61,8 @@ fun! s:RgSearch(txt)
   if &smartcase == 1
     let l:rgopts = l:rgopts . '-S '
   endif
-  silent! exe 'grep! ' . l:rgopts . a:txt
+  " Escaping Command-line special characters '#', '%' (:h :_%), and '|' (:h :bar)
+  silent! exe 'grep! ' . l:rgopts . escape(a:txt, "#%|")
   if len(getqflist())
     exe g:rg_window_location 'copen'
     redraw!


### PR DESCRIPTION
So that seaches like `:Rg matchit\# $VIMRUNTIME` are possible.

Escaping theses characters is necessary because `:grep` is a Command-line command after all, therefore '#' is a special character and is replaced with the alternate filename.